### PR TITLE
Fix some K&R C in pgplot that causes compilation errors

### DIFF
--- a/PGPLOT/pgdispd/getvisuals.c
+++ b/PGPLOT/pgdispd/getvisuals.c
@@ -28,6 +28,7 @@
 #include "figdisp.h"
 #include "globals.h"
 #include "messages.h"
+#include "pgdispd.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -323,7 +324,7 @@ int getvisuals()
 	while (res.lgcolors > 2)
 	{
 		if (lg.colors=getcolors(UseROVisual, &linevisual, &linecmap,
-			lg.pix, res.lgcolors, res.lgcolors, &linedepth)) break;
+                                        lg.pix, res.lgcolors, res.lgcolors, &linedepth, MAX_DEPTH, 1)) break;
 
 		/* lower our standards */
 		if (res.lgcolors > 16) res.lgcolors=16;

--- a/PGPLOT/pgdispd/mainloop.c
+++ b/PGPLOT/pgdispd/mainloop.c
@@ -57,6 +57,7 @@
 /* The program include files */
 #include "figdisp.h"
 #include "globals.h"
+#include "pgdispd.h"
 
 int mainloop()
 {

--- a/PGPLOT/pgdispd/pgdispd.h
+++ b/PGPLOT/pgdispd/pgdispd.h
@@ -1,0 +1,30 @@
+#ifndef PGDISPD_H
+#define PGDISPD_H
+
+#include "figdisp.h"
+
+int getcolors(int vistype,              /* The type of visual to use */
+              Visual **visual,          /* The visual actually used */
+              Colormap *cmap,           /* The color map actually used */
+              unsigned long *pix,       /* The pixels allocated */
+              int maxcolors,            /* The maximum number of colors to allocate */
+              int mincolors,            /* The minimum number of colors to allocate */
+              int *depth,               /* The depth of the visual actually used */
+              int maxdepth,             /* The maximum allowed visual depth */
+              int mindepth);            /* The minimum allowed visual depth */
+
+int proccom(unsigned short *buf,        /* the buffer of commands and arguments */
+            int len,                    /* the length of the buffer */
+            unsigned short *retbuf,     /* a buffer for return values */
+            int *retbuflen);            /* the length of retbuf */
+
+void returnbuf(short *msg,	/* the message to send to the client. */
+               int len,	        /* The length of the message. */
+               Window destwin);	/* The window who's atom should be changed. */
+
+int waitevent();
+
+int handlexevent(XEvent event,
+                 int *go_on);	/* whether the calling routine shoudl exit successfully */
+
+#endif

--- a/PGPLOT/pgdispd/resdb.c
+++ b/PGPLOT/pgdispd/resdb.c
@@ -47,6 +47,7 @@ static char rcsid[]="@(#)$Id: resdb.c 1118 2003-02-26 16:43:25Z cesrulib $";
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #ifndef VMS
 #include <pwd.h>
 #endif
@@ -1041,8 +1042,6 @@ char *dest;
 {
 	int uid;
 
-	extern char *getenv();
-	extern int getuid();
 	extern struct passwd *getpwuid();
 	struct passwd *pw;
 	register char *ptr;

--- a/PGPLOT/pgdispd/waitevent.c
+++ b/PGPLOT/pgdispd/waitevent.c
@@ -46,6 +46,7 @@
 #include "globals.h"
 #include "messages.h"
 #include "commands.h"
+#include "pgdispd.h"
 
 /* Choose one of the following to select either good response time or low */
 /* system load, keeping in mind what your system provides.  If none of the */


### PR DESCRIPTION
Implicit function declarations have been forbidden for 25 years. gcc has decided to no longer tolerate them.

_Many_ more issues in the code, these are just enough to get it through the compiler.

Better solution is `rm -rf PGPLOT`...