### PR TITLE
BUILD_SHARED_LIB -> BUILD_SHARED in hdf5

### DIFF
--- a/hdf5/acc_build_hdf5
+++ b/hdf5/acc_build_hdf5
@@ -15,7 +15,7 @@ func_configure_make_install () {
     if [ ! -e ALREADY_BUILT ]
     then
 	[ -n "${CMAKE_BINARY}" ] || CMAKE_BINARY=cmake
-	if [ "${BUILD_SHARED_LIBS}" -eq 1 ]
+	if [ "${BUILD_SHARED}" -eq 1 ]
 	then
 	    SHARED=ON
 	    STATIC=ON


### PR DESCRIPTION
Fix a typo in acc_build_hdf5

Didn't seem to cause issues, but gave an error message.